### PR TITLE
Update Bk3_Ch6_01.py

### DIFF
--- a/Book3_Ch06_Python_Codes/Bk3_Ch6_01.py
+++ b/Book3_Ch06_Python_Codes/Bk3_Ch6_01.py
@@ -19,7 +19,9 @@ def plot_surf(xx,yy,zz,caption):
     colors = cm.RdYlBu_r(norm_plt(zz))
 
     fig = plt.figure()
-    ax = fig.gca(projection='3d')
+    ax = fig.add_subplot(projection='3d')
+    # ax = plt.axes(projection='3d')
+    
     surf = ax.plot_surface(xx,yy,zz,
                            facecolors=colors, shade=False)
     surf.set_facecolor((0,0,0,0))


### PR DESCRIPTION
 #76 

```
ax = fig.gca(projection='3d')`
```
提示
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
Cell In[141], line 56
     54 zz = 2 + xx*0;
     55 caption = '$z - 2 = 0$';
---> 56 plot_surf (xx,yy,zz,caption)
     58 #%% y - z = 0
     59 zz = yy;

Cell In[141], line 13, in plot_surf(xx, yy, zz, caption)
     10 colors = cm.RdYlBu_r(norm_plt(zz))
     12 fig = plt.figure()
---> 13 ax = fig.gca(projection='3d')
     14 surf = ax.plot_surface(xx,yy,zz,
     15                        facecolors=colors, shade=False)
     16 surf.set_facecolor((0,0,0,0))

TypeError: FigureBase.gca() got an unexpected keyword argument 'projection'


改为
```
ax = fig.add_subplot(projection='3d')
```
或
```
ax = plt.axes(projection='3d')
```
后正常。