### PR TITLE
Update Bk3_Ch16_01.py

### DIFF
--- a/Book3_Ch16_Python_Codes/Bk3_Ch16_01.py
+++ b/Book3_Ch16_Python_Codes/Bk3_Ch16_01.py
@@ -253,34 +253,30 @@ colorbar = ax.contour(xx,yy, f_xy_zz,20,
 
 fig.colorbar(colorbar, ax=ax)
 
-for i in range(0,len(CS_y.allsegs[0])):
-
-    contour_points_x_y = CS_y.allsegs[0][i]
-    
-    contour_points_z = f_xy_fcn(contour_points_x_y[:,0],
-                                contour_points_x_y[:,1])
-    
-    
-    ax.plot3D(contour_points_x_y[:,0],
-              contour_points_x_y[:,1], 
-              contour_points_z,
-              color = '#339933',
-              linewidth = 1)
+for path in CS_x.get_paths():
+    for subpath in path._iter_connected_components():
+        contour_points_x_y = subpath.vertices
+        contour_points_z = f_xy_fcn(contour_points_x_y[:, 0],
+                                    contour_points_x_y[:, 1])
+            
+        ax.plot3D(contour_points_x_y[:, 0],
+                    contour_points_x_y[:, 1], 
+                    contour_points_z,
+                    color='#339933',
+                    linewidth=1)
 
 
-for i in range(0,len(CS_x.allsegs[0])):
-
-    contour_points_x_y = CS_x.allsegs[0][i]
-    
-    contour_points_z = f_xy_fcn(contour_points_x_y[:,0],
-                                contour_points_x_y[:,1])
-    
-    
-    ax.plot3D(contour_points_x_y[:,0],
-              contour_points_x_y[:,1], 
-              contour_points_z,
-              color = '#00448A',
-              linewidth = 1)
+for path in CS_y.get_paths():
+    for subpath in path._iter_connected_components():
+        contour_points_x_y = subpath.vertices
+        contour_points_z = f_xy_fcn(contour_points_x_y[:, 0],
+                                    contour_points_x_y[:, 1])
+            
+        ax.plot3D(contour_points_x_y[:, 0],
+                    contour_points_x_y[:, 1], 
+                    contour_points_z,
+                    color='#00448A',
+                    linewidth=1)
     
 ax.set_proj_type('ortho')
 


### PR DESCRIPTION
由于 matplotlib 在 3.8.0 版本中 将 contour 的 collections 属性弃用并将 contour 修改为 collections 的子类。因此需要使用 get_path 来获取等高线路径。